### PR TITLE
Fix variable name typo from artwordId to artworkId

### DIFF
--- a/app/src/main/java/com/tolodev/artic_gallery/data/repositories/ArtworksRepository.kt
+++ b/app/src/main/java/com/tolodev/artic_gallery/data/repositories/ArtworksRepository.kt
@@ -17,8 +17,8 @@ class ArtworksRepository @Inject constructor(
         return localDataSource.getArtworks()
     }
 
-    fun getFavoriteArtworkById(artwordId: Long): Flow<Artwork?> {
-        return localDataSource.getArtworkById(artwordId)
+    fun getFavoriteArtworkById(artworkId: Long): Flow<Artwork?> {
+        return localDataSource.getArtworkById(artworkId)
     }
 
     suspend fun saveArtwork(artwork: Artwork) {

--- a/app/src/main/java/com/tolodev/artic_gallery/ui/fragments/FavoriteArtworksFragment.kt
+++ b/app/src/main/java/com/tolodev/artic_gallery/ui/fragments/FavoriteArtworksFragment.kt
@@ -56,11 +56,11 @@ class FavoriteArtworksFragment : Fragment() {
         modelDataView.addAll(listOf(uiStatus))
     }
 
-    private fun showArtworkDetail(artwordId: Long) {
+    private fun showArtworkDetail(artworkId: Long) {
         (requireActivity() as MainActivity).hideBottomNavigationView()
         startDestination(
             FavoriteArtworksFragmentDirections.actionFavoriteArtworksFragmentToArtworkDetailFragment(
-                artwordId,
+                artworkId,
                 ArtworkFlow.FAVORITES.name
             ),
             this

--- a/app/src/main/java/com/tolodev/artic_gallery/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/tolodev/artic_gallery/ui/fragments/HomeFragment.kt
@@ -53,11 +53,11 @@ class HomeFragment : Fragment() {
         modelDataView.addAll(listOf(uiStatus))
     }
 
-    private fun showArtworkDetail(artwordId: Long) {
+    private fun showArtworkDetail(artworkId: Long) {
         (requireActivity() as MainActivity).hideBottomNavigationView()
         startDestination(
             HomeFragmentDirections.actionHomeFragmentToArtworkDetailFragment(
-                artwordId, ArtworkFlow.RECENT.name
+                artworkId, ArtworkFlow.RECENT.name
             ), this
         )
     }


### PR DESCRIPTION
## Summary
- fix `artwordId` typo in repository
- update method parameters in Home and FavoriteArtworks fragments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853878bb74083218049f0d522b490fe