### PR TITLE
Add ImageUrlGenerator test

### DIFF
--- a/app/src/test/java/com/tolodev/artic_gallery/ImageUrlGeneratorTest.kt
+++ b/app/src/test/java/com/tolodev/artic_gallery/ImageUrlGeneratorTest.kt
@@ -1,0 +1,14 @@
+package com.tolodev.artic_gallery
+
+import com.tolodev.artic_gallery.domain.models.ImageSize
+import com.tolodev.artic_gallery.domain.models.ImageUrlGenerator
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImageUrlGeneratorTest {
+    @Test
+    fun generateUrl_returnsMediumImageUrl() {
+        val url = ImageUrlGenerator.generateUrl("imageId", ImageSize.MEDIUM)
+        assertEquals("https://www.artic.edu/iiif/2/imageId/full/600,/0/default.jpg", url)
+    }
+}


### PR DESCRIPTION
## Summary
- add `ImageUrlGeneratorTest` to ensure MEDIUM URLs are built correctly

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68538abb3a94832194e589681e3c62ba